### PR TITLE
Fixed too broad rule

### DIFF
--- a/domains/blacklist/unwanted-iranian.txt
+++ b/domains/blacklist/unwanted-iranian.txt
@@ -204,7 +204,7 @@ ads.farakav.com
 #cdn.tabnak.ir # should not be blocked
 adserver.netshahr.com
 adivery.com
-cdn.
+cdn.adivery.com
 tavoos.net
 phoenixad.io
 hiperad.com


### PR DESCRIPTION
Fixed too broad rule that block too many legitimate websites: all cdn for all website

Introduced in: 8456c63

*Note*: as discussed [here](https://github.com/DRSDavidSoft/additional-hosts/commit/8456c63cc84b93254f5b6e971df89da8c7739779#r76359527) I'm assuming the initial intention was to block `cdn.adivery.com`